### PR TITLE
Use switch offset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/mssql",
-  "version": "2.6.5",
+  "version": "2.6.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/mssql",
-      "version": "2.6.5",
+      "version": "2.6.6",
       "license": "BSD-3-Clause",
       "dependencies": {
         "async": "^3.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/mssql",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/mssql",
-      "version": "2.6.6",
+      "version": "2.6.7",
       "license": "BSD-3-Clause",
       "dependencies": {
         "async": "^3.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,8 @@
         "jasmine": "^4.1.0",
         "jasmine-spec-reporter": "^7.0.0",
         "module-alias": "^2.2.2",
+        "moment": "^2.29.4",
+        "moment-timezone": "^0.5.39",
         "rimraf": "^3.0.2",
         "rollup": "^2.71.1",
         "rollup-plugin-dts": "^4.2.1",
@@ -4692,6 +4694,18 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
       "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
       "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.39",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.39.tgz",
+      "integrity": "sha512-hoB6suq4ISDj7BDgctiOy6zljBsdYT0++0ZzZm9rtxIvJhIbQ3nmbgSWe7dNFGurl6/7b1OUkHlmN9JWgXVz7w==",
+      "dev": true,
+      "dependencies": {
+        "moment": ">= 2.9.0"
+      },
       "engines": {
         "node": "*"
       }
@@ -9395,6 +9409,15 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
       "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
       "dev": true
+    },
+    "moment-timezone": {
+      "version": "0.5.39",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.39.tgz",
+      "integrity": "sha512-hoB6suq4ISDj7BDgctiOy6zljBsdYT0++0ZzZm9rtxIvJhIbQ3nmbgSWe7dNFGurl6/7b1OUkHlmN9JWgXVz7w==",
+      "dev": true,
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "jasmine": "^4.1.0",
     "jasmine-spec-reporter": "^7.0.0",
     "module-alias": "^2.2.2",
+    "moment": "^2.29.4",
+    "moment-timezone": "^0.5.39",
     "rimraf": "^3.0.2",
     "rollup": "^2.71.1",
     "rollup-plugin-dts": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/mssql",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "description": "MOST Web Framework MSSQL Data Adapter",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/mssql",
-  "version": "2.6.5",
+  "version": "2.6.6",
   "description": "MOST Web Framework MSSQL Data Adapter",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/spec/DateFunctions.spec.js
+++ b/spec/DateFunctions.spec.js
@@ -107,4 +107,35 @@ describe('DateFunctions', () => {
         });
     });
 
+    it('should use datetimeoffset', async () => {
+        await app.executeInTestTranscaction(async (context) => {
+            let user = await context.model('User').where('name').equal('alexis.rees@example.com')
+                .silent().getItem();
+            expect(user).toBeTruthy();
+            const now = new Date();
+            user.lastLogon = now;
+            await context.model('User').silent().save(user);
+            user = await context.model('User').where('name').equal('alexis.rees@example.com')
+                .silent().getItem();
+            expect(user.lastLogon).toEqual(now);
+        });
+    });
+
+    it('should use date', async () => {
+        await app.executeInTestTranscaction(async (context) => {
+            // get AMD Radeon R9 290
+            let product = await context.model('Product').where('name').equal('AMD Radeon R9 290')
+                .silent().getItem();
+            expect(product).toBeTruthy();
+            const now = new Date();
+            now.setMilliseconds(0);
+            let releaseDate = now;
+            product.releaseDate = new Date(releaseDate);
+            await context.model('Product').silent().save(product);
+            product = await context.model('Product').where('name').equal('AMD Radeon R9 290')
+                .silent().getItem();
+            expect(product.releaseDate).toEqual(now);
+        });
+    });
+
 });

--- a/spec/DateFunctions.spec.js
+++ b/spec/DateFunctions.spec.js
@@ -1,5 +1,5 @@
 import { TestApplication } from './TestApplication';
-
+import moment from 'moment';
 describe('DateFunctions', () => {
     /**
      * @type {TestApplication}
@@ -127,7 +127,7 @@ describe('DateFunctions', () => {
             let product = await context.model('Product').where('name').equal('AMD Radeon R9 290')
                 .silent().getItem();
             expect(product).toBeTruthy();
-            const now = new Date();
+            const now = moment(new Date()).startOf('day').toDate();
             now.setMilliseconds(0);
             let releaseDate = now;
             product.releaseDate = new Date(releaseDate);

--- a/spec/DateFunctions.spec.js
+++ b/spec/DateFunctions.spec.js
@@ -128,7 +128,6 @@ describe('DateFunctions', () => {
                 .silent().getItem();
             expect(product).toBeTruthy();
             const now = moment(new Date()).startOf('day').toDate();
-            now.setMilliseconds(0);
             let releaseDate = now;
             product.releaseDate = new Date(releaseDate);
             await context.model('Product').silent().save(product);

--- a/spec/TestApplication.js
+++ b/spec/TestApplication.js
@@ -10,7 +10,13 @@ const testConnectionOptions = {
     'server': process.env.DB_HOST,
     'port': parseInt(process.env.DB_PORT, 10),
     'user': process.env.DB_USER,
-    'database': 'test_db'
+    'database': 'test_db',
+    'timezone': 'Europe/Athens',
+    'options': {
+        'encrypt': false,
+        'trustServerCertificate': true,
+        'useUTC': true
+    }
 };
 
 if (process.env.DB_PASSWORD) {

--- a/spec/TestApplication.js
+++ b/spec/TestApplication.js
@@ -216,7 +216,6 @@ class TestApplication extends DataApplication {
                 return item.abstract ? false : true;
             });
             const sourceAdapter = new SqliteAdapter(sourceConnectionOptions);
-            const formatter = new MSSqlFormatter();
             for (let entityType of entityTypes) {
                 TraceUtils.log(`Upgrading ${entityType.name}`);
                 await new Promise((resolve, reject) => {

--- a/src/MSSqlFormatter.js
+++ b/src/MSSqlFormatter.js
@@ -1,6 +1,6 @@
 // MOST Web Framework Codename Zero Gravity Copyright (c) 2017-2022, THEMOST LP All rights reserved
 import { sprintf } from 'sprintf-js';
-import { QueryField, SqlUtils, SqlFormatter } from '@themost/query';
+import { QueryField, SqlFormatter } from '@themost/query';
 
 function zeroPad(number, length) {
     number = number || 0;
@@ -10,6 +10,8 @@ function zeroPad(number, length) {
     }
     return res;
 }
+
+
 
 /**
  * @class
@@ -21,8 +23,10 @@ class MSSqlFormatter extends SqlFormatter {
      */
     constructor() {
         super();
+        const offset = new Date().getTimezoneOffset();
         this.settings = {
-            nameFormat: '[$1]'
+            nameFormat: '[$1]',
+            timezone: (offset <= 0 ? '+' : '-') + zeroPad(-Math.floor(offset / 60), 2) + ':' + zeroPad(offset % 60, 2)
         };
     }
     formatLimitSelect(obj) {
@@ -219,15 +223,15 @@ class MSSqlFormatter extends SqlFormatter {
     }
 
     $year(p0) {
-        return sprintf('DATEPART(year, %s)', this.escape(p0));
+        return sprintf('DATEPART(year, SWITCHOFFSET(%s, \'%s\'))', this.escape(p0), this.settings.timezone);
     }
 
     $month(p0) {
-        return sprintf('DATEPART(month, %s)', this.escape(p0));
+        return sprintf('DATEPART(month, SWITCHOFFSET(%s, \'%s\'))', this.escape(p0), this.settings.timezone);
     }
 
     $dayOfMonth(p0) {
-        return sprintf('DATEPART(day, %s)', this.escape(p0));
+        return sprintf('DATEPART(day, SWITCHOFFSET(%s, \'%s\'))', this.escape(p0), this.settings.timezone);
     }
 
     $day(p0) {
@@ -235,11 +239,11 @@ class MSSqlFormatter extends SqlFormatter {
     }
 
     $hour(p0) {
-        return sprintf('DATEPART(hour, %s)', this.escape(p0));
+        return sprintf('DATEPART(hour, SWITCHOFFSET(%s, \'%s\'))', this.escape(p0), this.settings.timezone);
     }
 
     $minute(p0) {
-        return sprintf('DATEPART(minute, %s)', this.escape(p0));
+        return sprintf('DATEPART(minute, SWITCHOFFSET(%s, \'%s\'))', this.escape(p0), this.settings.timezone);
     }
 
     $minutes(p0) {
@@ -247,7 +251,7 @@ class MSSqlFormatter extends SqlFormatter {
     }
 
     $second(p0) {
-        return sprintf('DATEPART(second, %s)', this.escape(p0));
+        return sprintf('DATEPART(second, SWITCHOFFSET(%s, \'%s\'))', this.escape(p0), this.settings.timezone);
     }
 
     $seconds(p0) {


### PR DESCRIPTION
This PR validates the usage of `useUTC` param of tediousjs https://github.com/tediousjs/node-mssql#drivers-1 and updates date functions to use `SWITCOFFSET()` T-SQL function:

https://learn.microsoft.com/en-us/sql/t-sql/functions/switchoffset-transact-sql?redirectedfrom=MSDN&view=sql-server-ver16

`@themost/mssql` options may use `useUTC` param to disable converting date values with timezone.
```
{ "name":"development", "invariantName":"mssql", "default":true,
        "options": {
          "server":"localhost",
          "user":"user",
          "password":"password",
          "database":"test",
          "options": {
                "encrypt": false,
                "trustServerCertificate": true,
                "useUTC": false
          }
        }
    }
```
