### PR TITLE
set transaction isolation level

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,42 @@ Register MSSQL adapter on app.json as follows:
 
 If you are intended to use MSSQL data adapter as the default database adapter set the property "default" to true.
 
+### Transaction Isolation Level
+
+Transaction isolation level controls the locking and row versioning behavior of Transact-SQL statements issued by a connection to SQL Server.
+
+```sql
+SET TRANSACTION ISOLATION LEVEL
+    { READ UNCOMMITTED
+    | READ COMMITTED
+    | REPEATABLE READ
+    | SNAPSHOT
+    | SERIALIZABLE
+    }
+```
+
+[https://learn.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql?view=sql-server-ver16](https://learn.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql?view=sql-server-ver16)
+
+Use `options/transactionIsolationLevel` and define transaction isolation level:
+
+```json
+{
+    "name":"development",
+    "invariantName":"mssql",
+    "default":true,
+    "options": {
+        "server":"localhost",
+        "user":"user",
+        "password":"password",
+        "database":"test",
+        "options": {
+            "transactionIsolationLevel": "readCommitted"
+        }
+    }
+}
+```
+The possible values are `readUncommitted` | `readCommitted` | `repeatableRead` | `snapshot` | `serializable`
+
 ## Development
 `themost-mssql` is a sub-module of [ Most Web Framework data adapters project](https://github.com/themost-framework/themost-adapters)
 

--- a/TransactionIsolationLevel.js
+++ b/TransactionIsolationLevel.js
@@ -1,0 +1,33 @@
+
+const TransactionIsolationLevelEnum = {
+    readUncommitted: 'READ UNCOMMITTED',
+    readCommitted: 'READ COMMITTED',
+    repeatableRead: 'REPEATABLE READ',
+    snapshot: 'SNAPSHOT',
+    serializable: 'SERIALIZABLE'
+}
+
+Object.freeze(TransactionIsolationLevelEnum);
+
+class TransactionIsolationLevelFormatter {
+
+    /**
+     * @param {'readUncommitted' | 'readCommitted' | 'repeatableRead' | 'snapshot' | 'serializable'} isolationLevel 
+     * @returns {string}
+     */
+    format(isolationLevel) {
+        if (Object.prototype.hasOwnProperty.call(TransactionIsolationLevelEnum, isolationLevel)) {
+            let sql = 'SET TRANSACTION ISOLATION LEVEL';
+            sql += ' ';
+            sql += TransactionIsolationLevelEnum[isolationLevel];
+            return sql;
+        }
+        throw new TypeError('The specified transaction isolation level is invalid');
+    }
+
+}
+
+module.exports = {
+    TransactionIsolationLevelEnum,
+    TransactionIsolationLevelFormatter
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/mssql",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/mssql",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "description": "MOST Web Framework MSSQL Data Adapter",
   "main": "index.js",
   "scripts": {

--- a/spec/MSSqlAdapter.spec.js
+++ b/spec/MSSqlAdapter.spec.js
@@ -5,19 +5,22 @@ const ProductModel = require('./config/models/Product.json');
 const EmployeeModel = require('./config/models/Employee.json');
 // get options from environmet for testing
 const testConnectionOptions = {
-    "server": process.env.MSSQL_SERVER,
-    "port": process.env.MSSQL_SERVER_PORT,
-    "user": process.env.MSSQL_USER,
-    "password": process.env.MSSQL_PASSWORD,
-    "database": "test_themost_dev"
+    "server": process.env.DB_HOST,
+    "port": process.env.DB_PORT,
+    "user": process.env.DB_USER,
+    "password": process.env.DB_PASSWORD,
+    "database": "test_themost_dev",
+    "options": {
+        "transactionIsolationLevel": "readCommitted"
+    }
 };
 
 // get options from environmet for testing
 const masterConnectionOptions = {
-    "server": process.env.MSSQL_SERVER,
-    "port": process.env.MSSQL_SERVER_PORT,
-    "user": process.env.MSSQL_USER,
-    "password": process.env.MSSQL_PASSWORD,
+    "server": process.env.DB_HOST,
+    "port": process.env.DB_PORT,
+    "user": process.env.DB_USER,
+    "password": process.env.DB_PASSWORD,
     "database": "master"
 };
 


### PR DESCRIPTION
This PR enables the usage of transaction isolation level while executing commands. Define isolation under `options/transactionIsolationLevel`

```json
{
    "name":"development",
    "invariantName":"mssql",
    "default":true,
    "options": {
        "server":"localhost",
        "user":"user",
        "password":"password",
        "database":"test",
        "options": {
            "transactionIsolationLevel": "readCommitted"
        }
    }
}
```
The possible values are `readUncommitted` | `readCommitted` | `repeatableRead` | `snapshot` | `serializable`