### PR TITLE
set transaction isolation level

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,42 @@ Register MSSQL adapter on app.json as follows:
 
 If you are intended to use MSSQL data adapter as the default database adapter set the property "default" to true.
 
+### Transaction Isolation Level
+
+Transaction isolation level controls the locking and row versioning behavior of Transact-SQL statements issued by a connection to SQL Server.
+
+```sql
+SET TRANSACTION ISOLATION LEVEL
+    { READ UNCOMMITTED
+    | READ COMMITTED
+    | REPEATABLE READ
+    | SNAPSHOT
+    | SERIALIZABLE
+    }
+```
+
+[https://learn.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql?view=sql-server-ver16](https://learn.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql?view=sql-server-ver16)
+
+Use `options/transactionIsolationLevel` and define transaction isolation level:
+
+```json
+{
+    "name":"development",
+    "invariantName":"mssql",
+    "default":true,
+    "options": {
+        "server":"localhost",
+        "user":"user",
+        "password":"password",
+        "database":"test",
+        "options": {
+            "transactionIsolationLevel": "readCommitted"
+        }
+    }
+}
+```
+The possible values are `readUncommitted` | `readCommitted` | `repeatableRead` | `snapshot` | `serializable`
+
 ## Development
 `themost-mssql` is a sub-module of [ Most Web Framework data adapters project](https://github.com/themost-framework/themost-adapters)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/mssql",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/mssql",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "async": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/mssql",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "MOST Web Framework MSSQL Data Adapter",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/spec/TestApplication.js
+++ b/spec/TestApplication.js
@@ -15,7 +15,8 @@ const testConnectionOptions = {
     'options': {
         'encrypt': false,
         'trustServerCertificate': true,
-        'useUTC': true
+        'useUTC': true,
+        'transactionIsolationLevel': 'readCommitted'
     }
 };
 

--- a/src/TransactionIsolationLevel.js
+++ b/src/TransactionIsolationLevel.js
@@ -1,0 +1,32 @@
+const TransactionIsolationLevelEnum = {
+    readUncommitted: 'READ UNCOMMITTED',
+    readCommitted: 'READ COMMITTED',
+    repeatableRead: 'REPEATABLE READ',
+    snapshot: 'SNAPSHOT',
+    serializable: 'SERIALIZABLE'
+}
+
+Object.freeze(TransactionIsolationLevelEnum);
+
+class TransactionIsolationLevelFormatter {
+
+    /**
+     * @param {'readUncommitted' | 'readCommitted' | 'repeatableRead' | 'snapshot' | 'serializable'} isolationLevel 
+     * @returns {string}
+     */
+    format(isolationLevel) {
+        if (Object.prototype.hasOwnProperty.call(TransactionIsolationLevelEnum, isolationLevel)) {
+            let sql = 'SET TRANSACTION ISOLATION LEVEL';
+            sql += ' ';
+            sql += TransactionIsolationLevelEnum[isolationLevel];
+            return sql;
+        }
+        throw new TypeError('The specified transaction isolation level is invalid');
+    }
+
+}
+
+export {
+    TransactionIsolationLevelEnum,
+    TransactionIsolationLevelFormatter
+}


### PR DESCRIPTION
This PR enables the usage of transaction isolation level while executing commands. Define isolation under `options/transactionIsolationLevel`

```json
{
    "name":"development",
    "invariantName":"mssql",
    "default":true,
    "options": {
        "server":"localhost",
        "user":"user",
        "password":"password",
        "database":"test",
        "options": {
            "transactionIsolationLevel": "readCommitted"
        }
    }
}
```
The possible values are `readUncommitted` | `readCommitted` | `repeatableRead` | `snapshot` | `serializable`