### PR TITLE
Handle aborted transactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/mssql",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/mssql",
-  "version": "2.13.2",
+  "version": "2.13.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5287,8 +5287,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.debounce": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@themost/json": "^1.1.0",
     "async": "^3.2.3",
     "crypto-js": "^4.2.0",
+    "lodash": "^4.17.21",
     "mssql": "^9.3.2",
     "sprintf-js": "^1.1.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/mssql",
-  "version": "2.13.2",
+  "version": "2.13.3",
   "description": "MOST Web Framework MSSQL Data Adapter",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/mssql",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "description": "MOST Web Framework MSSQL Data Adapter",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/MSSqlAdapter.js
+++ b/src/MSSqlAdapter.js
@@ -8,7 +8,7 @@ import { MSSqlFormatter } from './MSSqlFormatter';
 import { TransactionIsolationLevelFormatter } from './TransactionIsolationLevel';
 import { AsyncSeriesEventEmitter, before, after } from '@themost/events';
 import { Guid } from '@themost/common';
-import assign from 'lodash/assign';
+import merge from 'lodash/merge';
 
 
 /**
@@ -195,7 +195,7 @@ class MSSqlAdapter {
             return callback();
         }
         // clone connection options
-        const connectionOptions = assign({
+        const connectionOptions = merge({
             id: this.id,
             options: {
                 encrypt: false,

--- a/src/MSSqlAdapter.js
+++ b/src/MSSqlAdapter.js
@@ -7,7 +7,8 @@ import { SqlUtils } from '@themost/query';
 import { MSSqlFormatter } from './MSSqlFormatter';
 import { TransactionIsolationLevelFormatter } from './TransactionIsolationLevel';
 import { AsyncSeriesEventEmitter, before, after } from '@themost/events';
-import { Guid } from '@themost/common'
+import { Guid } from '@themost/common';
+import assign from 'lodash/assign';
 
 
 /**
@@ -194,7 +195,7 @@ class MSSqlAdapter {
             return callback();
         }
         // clone connection options
-        const connectionOptions = Object.assign({
+        const connectionOptions = assign({
             id: this.id,
             options: {
                 encrypt: false,
@@ -211,12 +212,6 @@ class MSSqlAdapter {
                 transactionIsolationLevel = new TransactionIsolationLevelFormatter().format(level);
             }
         }
-        // connection.on('error', function(err) {
-        //     TraceUtils.error(err);
-        //     if (callbackAlreadyCalled === false) {
-        //      return callback(err);
-        //     } 
-        //  });
          connectionManager.get(connectionOptions, function(err, connection) {
             //callbackAlreadyCalled = true;
             if (err) {

--- a/src/MSSqlAdapter.js
+++ b/src/MSSqlAdapter.js
@@ -299,6 +299,10 @@ class MSSqlAdapter {
                 //begin transaction
                 self.transaction.begin(function (err) {
                     //error check (?)
+                    let rolledBack = false;
+                    self.transaction.on('rollback', aborted => {
+                        rolledBack = true;
+                    });
                     if (err) {
                         TraceUtils.error(err);
                         return callback(err);
@@ -309,6 +313,9 @@ class MSSqlAdapter {
                                 try {
                                     if (err) {
                                         if (self.transaction) {
+                                            if (rolledBack) {
+                                                return callback(err);
+                                            }
                                             return self.transaction.rollback(function(rollbackErr) {
                                                 self.transaction = null;
                                                 if (rollbackErr) {


### PR DESCRIPTION
This PR enables the handling of aborted transactions avoiding errors like "Transaction has been aborted" as it's being described by `node-mssql` documentation https://github.com/tediousjs/node-mssql#transaction