### PR TITLE
handle aborted transactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/mssql",
-  "version": "2.13.2",
+  "version": "2.13.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/mssql",
-  "version": "2.13.3",
+  "version": "2.13.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/mssql",
-  "version": "2.13.3",
+  "version": "2.13.4",
   "description": "MOST Web Framework MSSQL Data Adapter",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/mssql",
-  "version": "2.13.2",
+  "version": "2.13.3",
   "description": "MOST Web Framework MSSQL Data Adapter",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/MSSqlAdapter.js
+++ b/src/MSSqlAdapter.js
@@ -299,6 +299,10 @@ class MSSqlAdapter {
                 //begin transaction
                 self.transaction.begin(function (err) {
                     //error check (?)
+                    let rolledBack = false;
+                    self.transaction.on('rollback', aborted => {
+                        rolledBack = true;
+                    });
                     if (err) {
                         TraceUtils.error(err);
                         return callback(err);
@@ -309,6 +313,9 @@ class MSSqlAdapter {
                                 try {
                                     if (err) {
                                         if (self.transaction) {
+                                            if (rolledBack) {
+                                                return callback(err);
+                                            }
                                             return self.transaction.rollback(function(rollbackErr) {
                                                 self.transaction = null;
                                                 if (rollbackErr) {


### PR DESCRIPTION
This PR enables the handling of aborted transactions avoiding errors like "Transaction has been aborted" as it's being described by node-mssql documentation https://github.com/tediousjs/node-mssql#transaction