### PR TITLE
execute sql for custom identity columns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@themost/mssql",
-  "version": "2.15.2",
+  "version": "2.15.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@themost/mssql",
-      "version": "2.15.2",
+      "version": "2.15.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@themost/events": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themost/mssql",
-  "version": "2.15.2",
+  "version": "2.15.3",
   "description": "MOST Web Framework MSSQL Data Adapter",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/spec/MSSqlAdapter.spec.js
+++ b/spec/MSSqlAdapter.spec.js
@@ -389,4 +389,38 @@ describe('MSSqlAdapter', () => {
         });
     });
 
+    it('should use custom identify of a missing column', async () => {
+        await app.executeInTestTranscaction(async (context) => {
+            const db = context.db;
+            let exists = await db.table('Table2').existsAsync();
+            expect(exists).toBeFalsy();
+            await db.table('Table2').createAsync([
+                {
+                    name: 'id',
+                    type: 'Integer',
+                    primary: true,
+                    nullable: false
+                },
+                {
+                    name: 'name',
+                    type: 'Text',
+                    size: 255,
+                    nullable: false
+                }
+            ]);
+            exists = await db.table('Table2').existsAsync();
+            expect(exists).toBeTruthy();
+
+            // insert a row
+            let id = await db.selectIdentityAsync('Table2', 'index');
+            expect(id).toBe(2);
+            await db.executeAsync(new QueryExpression().insert({
+                id: id,
+                name: 'Test Name'
+            }).into('Table2'));
+            
+
+        });
+    });
+
 });

--- a/src/MSSqlAdapter.js
+++ b/src/MSSqlAdapter.js
@@ -530,7 +530,7 @@ class MSSqlAdapter {
 IF NOT EXISTS (SELECT * FROM [sysobjects] WHERE [name] = ${formatter.escape(sequenceName)} AND [type] = 'SO')
     IF EXISTS(SELECT [c0].* FROM [syscolumns] AS [c0] INNER JOIN sysobjects s0 ON c0.[id]=s0.[id] AND [s0].[type]='U'
         WHERE [c0].[name]=${formatter.escape(attribute)} AND [s0].name = ${formatter.escape(table)} AND SCHEMA_NAME(s0.[uid]) = ${formatter.escape(schema)})
-    SELECT ISNULL(MAX(${formatter.escapeName(attribute)}), 0) AS [value] FROM ${formatter.escapeName(entity)};`, null).then((results) => {
+    EXEC sp_executesql N'SELECT ISNULL(MAX(${formatter.escapeName(attribute)}), 0) AS [value] FROM ${formatter.escapeName(entity)}'`, null).then((results) => {
             const startValue = (results && results.length > 0) ? results[0].value : 1;
             // create sequence if it does not exist
                     return db.executeAsync(`


### PR DESCRIPTION
This PR changes the way of searching for the max value of a custom identity column because MSSQL fails to execute this statement if the column does not exists. The last statement of the execution -if the sequence does not exist and should be created- uses `EXEC sp_executesql` avoiding errors for missing columns.